### PR TITLE
Force building on Windows i386

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
 VignetteBuilder: knitr
 Encoding: UTF-8
+Biarch: true
 Remotes:
     topepo/Cubist#38

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,4 +29,4 @@ VignetteBuilder: knitr
 Encoding: UTF-8
 Biarch: true
 Remotes:
-    topepo/Cubist#38
+    topepo/Cubist

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(
     person("Rulequest Research Pty Ltd.", role = "cph", comment = "Copyright holder of imported C code")) 
 Maintainer: Max Kuhn <mxkuhn@gmail.com>
 Description: C5.0 decision trees and rule-based models for pattern recognition that extend the work of Quinlan (1993, ISBN:1-55860-238-0).
-Imports: partykit, Cubist (>= 0.2.4)
+Imports: partykit, Cubist (>= 0.2.40.9000)
 Depends: R (>= 2.10.0)
 Suggests: 
     covr,
@@ -27,3 +27,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
 VignetteBuilder: knitr
 Encoding: UTF-8
+Remotes:
+    topepo/Cubist#38


### PR DESCRIPTION
Same as https://github.com/topepo/Cubist/pull/38
Requires a Remote on that PR since C5.0 Imports Cubist. Remove the Remote on the PR after merging that PR.