### PR TITLE
Switch `Confidence` from `float` to `double` to align with `global.c`

### DIFF
--- a/src/extern.h
+++ b/src/extern.h
@@ -69,8 +69,9 @@ extern String FileStem;
 
 extern Tree *Raw, *Pruned, WTree;
 
-extern float Confidence, SampleFrac, *Vote, *BVoteBlock, **MCost, **NCost,
-    *WeightMul;
+extern float SampleFrac, *Vote, *BVoteBlock, **MCost, **NCost, *WeightMul;
+
+extern double Confidence;
 
 extern CRule *MostSpec;
 


### PR DESCRIPTION
This should fix this LTO warning

```c
extern.h:72:14: warning: type of 'Confidence' does not match original declaration [-Wlto-type-mismatch]
   72 | extern float Confidence, SampleFrac, *Vote, *BVoteBlock, **MCost, **NCost,
      |              ^
global.c:138:8: note: type 'double' should match type 'float'
  138 | double Confidence; /* set by classify() */
      |        ^
global.c:138:8: note: 'Confidence' was previously declared here
global.c:138:8: note: code may be misoptimized unless '-fno-strict-aliasing' is used
```

It looks like it was supposed to be a `double` based on its usage in `classify.c`