### PR TITLE
Applying the same patch as topepo/Cubist#50

### DIFF
--- a/src/utility.c
+++ b/src/utility.c
@@ -766,7 +766,7 @@ void CValToStr(ContValue CV, Attribute Att, String DS, size_t DS_size)
     DayToDate(floor(CV / 1440) + TSBase, DS, DS_size);
     DS[10] = ' ';
     Mins = rint(CV) - floor(CV / 1440) * 1440;
-    SecsToTime(Mins * 60, DS + 11, DS_size);
+    SecsToTime(Mins * 60, DS + 11, DS_size - 11);
   } else if (DateVal(Att)) {
     DayToDate(CV, DS, DS_size);
   } else if (TimeVal(Att)) {


### PR DESCRIPTION
It does not look like we need the patch from topepo/Cubist#49, because that `snprintf()` call doesn't exist in C5.0 (if I am reading the code correctly)