### PR TITLE
fix more warnings from windows

### DIFF
--- a/src/classify.c
+++ b/src/classify.c
@@ -499,7 +499,7 @@ rule for class Best or the scaled ClassSum[Best] value  */
 int FindOutcome(DataRec Case, Condition OneCond)
 /*  -----------  */
 {
-  DiscrValue v, Outcome;
+  DiscrValue v, Outcome = 0;
   Attribute Att;
 
   Att = OneCond->Tested;

--- a/src/construct.c
+++ b/src/construct.c
@@ -66,7 +66,7 @@ void ConstructClassifiers(void)
   double ErrWt, OKWt, ExtraErrWt, NFact, MinWt = 1.0, a, b;
   ClassNo c, Pred, Real, Best;
   static ClassNo *Wrong = Nil;
-  int BaseLeaves;
+  int BaseLeaves = 0;
   Boolean NoStructure, CheckExcl;
   float *BVote;
 
@@ -430,7 +430,7 @@ void EvaluateSingle(int Flags)
 /*   --------------  */
 {
   ClassNo RealClass, PredClass;
-  int x, u, SaveUtility;
+  int x, u, SaveUtility = 0;
   CaseNo *ConfusionMat, *Usage, i, Errs = 0;
 #ifdef VerbOpt
   CaseNo RawErrs = 0;

--- a/src/contin.c
+++ b/src/contin.c
@@ -50,8 +50,8 @@
 void EvalContinuousAtt(Attribute Att, CaseNo Fp, CaseNo Lp)
 /*   -----------------  */
 {
-  CaseNo i, j, BestI, Tries = 0;
-  double LowInfo, LHInfo, LeastInfo = 1E38, w, BestGain, BestInfo,
+  CaseNo i, j, BestI = 0, Tries = 0;
+  double LowInfo, LHInfo, LeastInfo = 1E38, w, BestGain, BestInfo = 0,
                           ThreshCost = 1;
   ClassNo c;
   ContValue Interval;

--- a/src/defns.h
+++ b/src/defns.h
@@ -173,7 +173,7 @@
 #define EmptyNA(T) (T->Branch[1]->Cases < 0.01)
 
 #define Before(n1, n2)                                                         \
-  (n1->Tested < n2->Tested || n1->Tested == n2->Tested && n1->Cut < n2->Cut)
+  (n1->Tested < n2->Tested || (n1->Tested == n2->Tested && n1->Cut < n2->Cut))
 
 #define Swap(a, b)                                                             \
   {                                                                            \

--- a/src/discr.c
+++ b/src/discr.c
@@ -92,8 +92,8 @@ void EvalOrderedAtt(Attribute Att, CaseCount Cases)
   double *HoldFreqRow, SplitFreq[4];
   ClassNo c;
   int Tries = 0;
-  DiscrValue v, BestV;
-  double BaseInfo, ThisGain, BestInfo, BestGain = None;
+  DiscrValue v, BestV = 0;
+  double BaseInfo, ThisGain, BestInfo = 0, BestGain = None;
 
   SetDiscrFreq(Att);
   KnownCases = Cases - GEnv.ValFreq[0];

--- a/src/getnames.c
+++ b/src/getnames.c
@@ -417,7 +417,7 @@ void ExplicitAtt(FILE *Nf)
 
       AttValName[MaxAtt] = Alloc(v + 3, String);
       /* TODO: specify "size_t" as type of v? ,nc ,2012-05-21 */
-      AttValName[MaxAtt][0] = (char *)(long)v + 1;
+      AttValName[MaxAtt][0] = (char *)(intptr_t)(v + 1);
       AttValName[MaxAtt][(MaxAttVal[MaxAtt] = 1)] = strdup("N/A");
     } else if (!strcmp(Buffer, "ignore")) {
       SpecialStatus[MaxAtt] = EXCLUDE;

--- a/src/mcost.c
+++ b/src/mcost.c
@@ -38,7 +38,7 @@
 void GetMCosts(FILE *Cf)
 /*   ---------  */
 {
-  ClassNo Pred, Real, p, r;
+  ClassNo Pred = 0, Real = 0, p, r;
   char Name[1000];
   CaseNo i;
   float Val, Sum = 0;
@@ -120,7 +120,7 @@ if not using cost weighting  */
 void PredictGetMCosts(FILE *Cf)
 /*   ---------  */
 {
-  ClassNo Pred, Real, p, r;
+  ClassNo Pred = 0, Real = 0, p, r;
   char Name[1000];
   float Val;
 

--- a/src/modelfiles.c
+++ b/src/modelfiles.c
@@ -448,7 +448,7 @@ void AsciiOut(String Pre, String S)
 void ReadHeader(void)
 /*   ---------  */
 {
-  Attribute Att;
+  Attribute Att = 0;
   DiscrValue v;
   char *p, Dummy;
   int Year, Month, Day;
@@ -521,7 +521,7 @@ void ReadHeader(void)
 void PredictReadHeader(void)
 /*   ---------  */
 {
-  Attribute Att;
+  Attribute Att = 0;
   DiscrValue v;
   char *p, Dummy;
   int Year, Month, Day;

--- a/src/siftrules.c
+++ b/src/siftrules.c
@@ -686,7 +686,7 @@ void CountVotes(CaseNo i)
 /*                                                                       */
 /*************************************************************************/
 
-#define Prefer(d, c1, c2) ((d) > 0 || (d) == 0 && c1 < c2)
+#define Prefer(d, c1, c2) ((d) > 0 || ((d) == 0 && c1 < c2))
 
 void UpdateDeltaErrs(CaseNo i, double Delta, RuleNo Toggle)
 /*   ---------------  */

--- a/src/subset.c
+++ b/src/subset.c
@@ -69,10 +69,10 @@ void InitialiseBellNumbers(void)
 void EvalSubset(Attribute Att, CaseCount Cases)
 /*   ----------  */
 {
-  DiscrValue V1, V2, V3, BestV1, BestV2, InitialBlocks, First = 1, Prelim = 0;
+  DiscrValue V1, V2, V3, BestV1, BestV2 = 0, InitialBlocks, First = 1, Prelim = 0;
   ClassNo c;
   double BaseInfo, ThisGain, ThisInfo, Penalty, UnknownRate, Val, BestVal,
-      BestGain, BestInfo, PrevGain, PrevInfo;
+      BestGain, BestInfo = 0, PrevGain, PrevInfo;
   int MissingValues = 0;
   CaseCount KnownCases;
   Boolean Better;

--- a/src/trees.c
+++ b/src/trees.c
@@ -315,7 +315,7 @@ int MaxLine(Tree T)
 {
   Attribute Att;
   DiscrValue v, vv;
-  int Ll, One, MaxLl = 0;
+  int Ll = 0, One, MaxLl = 0;
 
   Att = T->Tested;
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -842,10 +842,8 @@ void Cleanup(void)
 
   extern DataRec *Blocked;
   extern Tree *SubDef;
-  extern int SubSpace, ActiveSpace, PropValSize;
-  extern RuleNo *Active;
+  extern int SubSpace;
   extern float *AttImp;
-  extern char *PropVal;
   extern Boolean *Split, *Used;
   extern FILE *Uf;
 


### PR DESCRIPTION
Based on win-devel results. Building with GCC 14.3.0 on Windows (rtools45) produces multiple compiler warnings:

```
classify.c:532:10: warning: 'Outcome' may be used uninitialized [-Wmaybe-uninitialized]
construct.c:294:25: warning: 'BaseLeaves' may be used uninitialized [-Wmaybe-uninitialized]
construct.c:576:13: warning: 'SaveUtility' may be used uninitialized [-Wmaybe-uninitialized]
contin.c:160:26: warning: 'BestI' may be used uninitialized [-Wmaybe-uninitialized]
contin.c:173:15: warning: 'BestInfo' may be used uninitialized [-Wmaybe-uninitialized]
discr.c:168:14: warning: 'BestV' may be used uninitialized [-Wmaybe-uninitialized]
discr.c:167:15: warning: 'BestInfo' may be used uninitialized [-Wmaybe-uninitialized]
getnames.c:420:31: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
mcost.c:66:26: warning: 'Real' may be used uninitialized [-Wmaybe-uninitialized]
mcost.c:147:26: warning: 'Real' may be used uninitialized [-Wmaybe-uninitialized]
modelfiles.c:495:16: warning: 'Att' may be used uninitialized [-Wmaybe-uninitialized]
modelfiles.c:561:16: warning: 'Att' may be used uninitialized [-Wmaybe-uninitialized]
rules.c:72:37: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
siftrules.c:720:13: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
siftrules.c:727:13: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
subset.c:273:5: warning: 'BestV2' may be used uninitialized [-Wmaybe-uninitialized]
subset.c:271:9: warning: 'BestInfo' may be used uninitialized [-Wmaybe-uninitialized]
trees.c:379:10: warning: 'Ll' may be used uninitialized [-Wmaybe-uninitialized]
utility.c:848:16: warning: unused variable 'PropVal' [-Wunused-variable]
utility.c:846:18: warning: unused variable 'Active' [-Wunused-variable]
utility.c:845:37: warning: unused variable 'PropValSize' [-Wunused-variable]
utility.c:845:24: warning: unused variable 'ActiveSpace' [-Wunused-variable]
```

### Solution

#### 1. Uninitialized Variable Warnings

Initialized variables to 0 at declaration:

| File | Variable | Function |
|------|----------|----------|
| `classify.c` | `Outcome` | `FindOutcome` |
| `construct.c` | `BaseLeaves` | `ConstructClassifiers` |
| `construct.c` | `SaveUtility` | `EvaluateSingle` |
| `contin.c` | `BestI`, `BestInfo` | `EvalContinuousAtt` |
| `discr.c` | `BestV`, `BestInfo` | `EvalOrderedAtt` |
| `mcost.c` | `Pred`, `Real` | `GetMCosts`, `PredictGetMCosts` |
| `modelfiles.c` | `Att` | `ReadHeader`, `PredictReadHeader` |
| `subset.c` | `BestV2`, `BestInfo` | `EvalSubset` |
| `trees.c` | `Ll` | `MaxLine` |

#### 2. Integer-to-Pointer Cast Warning

In `getnames.c:420`, changed `(char *)(long)v + 1` to `(char *)(intptr_t)(v + 1)`.

The original cast assumes `long` matches pointer size, which is false on 64-bit Windows (LLP64 model: `long` is 32-bit, pointers are 64-bit). Using `intptr_t` ensures portable behavior across all platforms.

#### 3. Operator Precedence Warnings

Added explicit parentheses around `&&` expressions in macros:

| File | Macro | Original | Fixed |
|------|-------|----------|-------|
| `defns.h` | `Before` | `a \|\| b && c` | `a \|\| (b && c)` |
| `siftrules.c` | `Prefer` | `a \|\| b && c` | `a \|\| (b && c)` |

#### 4. Unused Variable Warnings

Removed unused `extern` declarations in `utility.c`:
- `ActiveSpace`
- `PropValSize`
- `Active`
- `PropVal`
